### PR TITLE
Security and Compatibility Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ player/PS*
 *.top
 TODO
 src/todo/act_combat.c
+src/imp_table.c
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,10 @@
-CC      = gcc
-PROF    =
-NOCRYPT =
-C_FLAGS = -O -g -Wall -std=gnu99 $(PROF) $(NOCRYPT)
-L_FLAGS = -lcrypt -lz -lm -lcares
+CC              = gcc
+PROF            =
+NOCRYPT         =
+C_FLAGS         = -O -g -Wall -std=gnu99 $(PROF) $(NOCRYPT)
+L_FLAGS         = -lz -lm -lcares
+L_FLAG_CRYPT    = -lcrypt
+EXECUTABLE_NAME = ground0
 
 OBJDIR  = .obj
 
@@ -11,19 +13,27 @@ SRC     = act_comm.c act_obj.c db.c interp.c social-edit.c \
 	  update.c act_move.c comm.c handler.c save.c string.c \
 	  mccp.c net.c utils.c poll.c rank.c mob_vehicle.c \
 	  act_use.c act_combat.c reboot.c telnet.c inline.c dns.c \
-	  top.c behave.c ban.c act_profile.c graph.c pfile.c
+	  top.c behave.c ban.c act_profile.c graph.c pfile.c imp_table.c
 O_FILES = $(foreach f,$(SRC:.c=.o),$(OBJDIR)/$(f))
 D_FILES = $(foreach f,$(SRC:.c=.d),$(OBJDIR)/$(f))
 
 default: ground0
 -include $(D_FILES)
 
-ground0: $(O_FILES)
-	@echo Creating executable $@ ...
-	@$(CC) -o ground0 $(O_FILES) $(L_FLAGS)
-	@chmod g=rwx ground0
+osx: $(O_FILES)
+	@echo Creating executable $(EXECUTABLE_NAME) \(without -lcrypt\) ...
+	@$(CC) -o $(EXECUTABLE_NAME) $(O_FILES) $(L_FLAGS)
+	@chmod g=rwx $(EXECUTABLE_NAME)
 	@chmod -R g=rw $(OBJDIR) *.[ch]
 	@echo "DONE."
+
+ground0: $(O_FILES)
+	@echo Creating executable $(EXECUTABLE_NAME) ...
+	@$(CC) -o $(EXECUTABLE_NAME) $(O_FILES) $(L_FLAGS) $(L_FLAG_CRYPT)
+	@chmod g=rwx $(EXECUTABLE_NAME)
+	@chmod -R g=rw $(OBJDIR) *.[ch]
+	@echo "DONE."
+
 clean:
 	rm -f ground0
 	rm -f $(OBJDIR)/*

--- a/src/README
+++ b/src/README
@@ -6,8 +6,8 @@ that were temp. deprecated (like the mech code).
 
 ## HOW TO INSTALL ##
 First, edit localconfig.h and change logging settings to your preference.
-Next, make the necessary changes in comm.c to add yourself to the
-list of administrators (search for 'imp_table' and scroll down).
+Next, make the necessary changes in imp_table.c to add yourself to the
+list of administrators. Make sure you don't commit these changes back to Git!
 
 Requirements:
 gcc, make, libcares, and a standard set of libraries (case Cnetos 6 install).

--- a/src/act_comm.c
+++ b/src/act_comm.c
@@ -19,6 +19,7 @@
 
 #include "ground0.h"
 #include "telnet.h"
+#include "imp_table.h"
 
 extern char *guild_list[];
 

--- a/src/act_info.c
+++ b/src/act_info.c
@@ -22,6 +22,7 @@
 #include    "ansi.h"
 #include    "db.h"
 #include    "telnet.h"
+#include    "imp_table.h"
 
 /* command procedures needed */
 DECLARE_DO_FUN (do_exits);

--- a/src/comm.c
+++ b/src/comm.c
@@ -40,6 +40,7 @@
 #include    "mccp.h"
 #include    "telnet.h"
 #include    "ban.h"
+#include    "imp_table.h"
 
 #include    <sys/wait.h>
 #include    <sys/stat.h>
@@ -1479,17 +1480,7 @@ get_god (char *a_name)
     return NULL;
 }
 
-/* This was "hard coded for security reasons" by previous maintainers at some point. */
-
-/* Format is {"Login name", Trust Level, "Character name", "login name's password", ""}
- * For example: {"Greg", 10, "Snoopy", "password", ""} to login as Greg and play
- * the character named Snoopy.  Note that "password" applies to Greg and not Snoopy, which
- * must have its own separate password. Trust levels are shown in src/ground0.h */
-
-const struct god_type imp_table[] = {
-    {"Test", 10, "Test", "test", ""}
-};
-
+/* The imp_table definition has been moved to its own file, imp_table.c. */
 
 static void
 finish_newbie (struct char_data *ch)

--- a/src/db.c
+++ b/src/db.c
@@ -2161,7 +2161,6 @@ load_notes (void)
     }
 
     strcpy(strArea, NOTE_FILE);
-    fp = fp;
     logmesg("Load_notes: bad key word.");
     exit(STATUS_ERROR);
     return;

--- a/src/ground0.h
+++ b/src/ground0.h
@@ -66,6 +66,14 @@
 #define DECLARE_DO_FUN( fun )       DO_FUN    fun
 #endif
 
+// Fix for OSX's NTELOPTS only being ~36, while MCCP requires a flag with value 86
+// Magic number '87' (TELOPT_COMPRESS2 + 1) used here since we can't include telnet.h cleanly.
+#define TELOPT_COMPRESS2_PLUS_1 87
+#if NTELOPTS < TELOPT_COMPRESS2_PLUS_1
+  #undef NTELOPTS
+  #define NTELOPTS TELOPT_COMPRESS2_PLUS_1
+#endif
+
 /* system calls */
 int unlink();
 int system();

--- a/src/imp_table.c
+++ b/src/imp_table.c
@@ -1,0 +1,15 @@
+#include "ground0.h"
+
+/* This was "hard coded for security reasons" by previous maintainers at some point. */
+
+/* Subsequently moved from comm.c to here so that a .gitignore could be written for
+ * this file, making it harder to accidentally push your own login info back to Git. */
+
+/* Format is {"Login name", Trust Level, "Character name", "login name's password", ""}
+ * For example: {"Greg", 10, "Snoopy", "password", ""} to login as Greg and play
+ * the character named Snoopy.  Note that "password" applies to Greg and not Snoopy, which
+ * must have its own separate password. Trust levels are shown in src/ground0.h */
+
+const struct god_type imp_table[] = {
+    {"Test", 10, "Test", "test", ""}
+};

--- a/src/imp_table.h
+++ b/src/imp_table.h
@@ -1,0 +1,1 @@
+extern const struct god_type imp_table[];

--- a/src/memory.c
+++ b/src/memory.c
@@ -298,7 +298,9 @@ f_free_mem (void *pMem, int sMem, char *filename, int line_num)
                 (get_mem_reference(pMem, &temp_alloc_list))->line_num,
                 filename, line_num);
         logmesg(log_buf);
-        *((char *) NULL) = 5;
+        
+        // Crash the thread. Previously used ``*((char *) NULL) = 5;``
+        __builtin_trap();
         exit(STATUS_ERROR);
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -161,7 +161,7 @@ logmesg (const char *fmt, ...)
 {
 #ifdef LOG_STDOUT
     time_t t = time(0);
-    char timestr[1000], buf2[MAX_STRING_LENGTH];
+    char timestr[1000];
     struct tm * lt = localtime(&t);
 #endif
 
@@ -176,8 +176,7 @@ logmesg (const char *fmt, ...)
 
 #ifdef LOG_STDOUT
     strftime(timestr, 1000, "%a %b %d %Y, %T", lt);
-    sprintf(buf2, "%s: %s\r\n", timestr, buf);
-    fprintf(stdout, buf2);
+    fprintf(stdout, "%s: %s\r\n", timestr, buf);
 #endif
 }
 


### PR DESCRIPTION
*OS X compatibility changes*
- Added an OS X makefile mode `make osx` that gets rid of -lcrypt.
- Added OS X compatibility for NTELOPTS-- defined as `#define	NTELOPTS	(1+TELOPT_NEW_ENVIRON)` aka 40 in OS X's telnet.h, but needs to be 87 for MCCP to work.

*imp_table changes*
- Moved imp_table from comm.c to its own file, `imp_table.c`.
- Added header includes for new `imp_table.h` to files that use this table.
- Added a .gitignore for `imp_table.c` to prevent people from accidentally pushing their own password to Git.

*misc changes*
- Fixed a typo in the newbie help message.
- Fixed assignment to NULL, which has variable behavior, and replaced it with a thread trap.
- Fixed non-secure use of fprintf, which could be used to leak memory contents to log.